### PR TITLE
Support switching drivers between vfio-pci and nvidia

### DIFF
--- a/assets/state-vfio-manager/0600_daemonset.yaml
+++ b/assets/state-vfio-manager/0600_daemonset.yaml
@@ -22,45 +22,27 @@ spec:
         nvidia.com/gpu.deploy.vfio-manager: "true"
       priorityClassName: system-node-critical
       serviceAccountName: nvidia-vfio-manager
-      initContainers:
-        - name: k8s-driver-manager
-          image: "FILLED BY THE OPERATOR"
-          imagePullPolicy: IfNotPresent
-          command: ["driver-manager"]
-          args: ["uninstall_driver"]
-          env:
-          - name: NODE_NAME
-            valueFrom:
-              fieldRef:
-                fieldPath: spec.nodeName
-          # always use runc for driver containers
-          - name: NVIDIA_VISIBLE_DEVICES
-            value: void
-          - name: ENABLE_AUTO_DRAIN
-            value: "false"
-          - name: OPERATOR_NAMESPACE
-            valueFrom:
-              fieldRef:
-                fieldPath: metadata.namespace
-          securityContext:
-            privileged: true
-          volumeMounts:
-            - name: run-nvidia
-              mountPath: /run/nvidia
-              mountPropagation: Bidirectional
-            - name: host-root
-              mountPath: /host
-              readOnly: true
-              mountPropagation: HostToContainer
-            - name: host-sys
-              mountPath: /sys
       containers:
         - name: nvidia-vfio-manager
           image: "FILLED BY THE OPERATOR"
           imagePullPolicy: IfNotPresent
           command: ["/bin/bash", "-c"]
           args:
-            - /bin/vfio-manage.sh bind --all && sleep inf
+            - driver-manager switch_driver && sleep inf
+          env:
+            - name: NODE_NAME
+              valueFrom:
+                fieldRef:
+                  fieldPath: spec.nodeName
+            # always use runc for driver containers
+            - name: NVIDIA_VISIBLE_DEVICES
+              value: void
+            - name: ENABLE_GPU_POD_EVICTION
+              value: "true"
+            - name: OPERATOR_NAMESPACE
+              valueFrom:
+                fieldRef:
+                  fieldPath: metadata.namespace
           resources:
             limits:
               memory: 200Mi
@@ -83,7 +65,7 @@ spec:
           lifecycle:
             preStop:
               exec:
-                command: ["/bin/sh", "-c", "/bin/vfio-manage.sh unbind --all"]
+                command: ["/bin/bash", "-c", "vfio-manage unbind --all-to-nvidia true"]
       terminationGracePeriodSeconds: 30
       volumes:
         - name: nvidia-vfio-manager

--- a/controllers/object_controls.go
+++ b/controllers/object_controls.go
@@ -1715,12 +1715,6 @@ func TransformKataManager(obj *appsv1.DaemonSet, config *gpuv1.ClusterPolicySpec
 
 // TransformVFIOManager transforms VFIO-PCI Manager daemonset with required config as per ClusterPolicy
 func TransformVFIOManager(obj *appsv1.DaemonSet, config *gpuv1.ClusterPolicySpec, n ClusterPolicyController) error {
-	// update k8s-driver-manager initContainer
-	err := transformDriverManagerInitContainer(obj, &config.VFIOManager.DriverManager)
-	if err != nil {
-		return fmt.Errorf("failed to transform k8s-driver-manager initContainer for VFIO Manager: %v", err)
-	}
-
 	// update image
 	image, err := gpuv1.ImagePath(&config.VFIOManager)
 	if err != nil {


### PR DESCRIPTION
Related to k8s-driver-manager [#2](https://github.com/easystack/k8s-driver-manager/pull/2)

**改动说明**
将k8s-driver-manager改为普通容器，因为在preStop中可能会使用driver-manager等待用户清理GPU客户端容器的功能。但目前等待用户时间不确定，而容器的terminationGracePeriodSeconds时间有限，会使得后续代码无法运行并产生错误，所以preStop仍采用之前直接vfio-manage unbind的方式，同时加上了切换为nvidia驱动的功能。